### PR TITLE
feat: 관리자 페이지 > 목록

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,11 +1,12 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
-import { AdminPage } from "./pages/admin";
+import { AdminReadPage } from "./pages/admin/read";
 import { ContactPage } from "./pages/contact";
 import { DeliveryPage } from "./pages/delivery";
 import { DetailPage } from "./pages/detail";
 import { DiscoveryPage } from "./pages/discovery";
 import { MainPage } from "./pages/main";
+import { AdminPage } from "./pages/admin";
 
 const AppRouter = () => {
   return (
@@ -19,7 +20,8 @@ const AppRouter = () => {
         <Route path="/delivery" element={<DeliveryPage />} />
 
         {/* 관리자 */}
-        <Route path="/stella/admin" element={<AdminPage />} />
+        <Route path="/stella/admin" element={<AdminReadPage />} />
+        <Route path="/stella/admin/write" element={<AdminPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/pages/admin/read/AdminReadStyle.css.ts
+++ b/src/pages/admin/read/AdminReadStyle.css.ts
@@ -1,0 +1,12 @@
+import { style } from "@vanilla-extract/css";
+
+export const AdminReadWrapper = style({
+  padding: "30px",
+  display: "flex",
+  justifyContent: "center",
+  flexDirection: "column",
+  width: "90vw",
+  overflowY: "scroll",
+  paddingBottom: "30px",
+});
+

--- a/src/pages/admin/read/index.tsx
+++ b/src/pages/admin/read/index.tsx
@@ -1,0 +1,155 @@
+import { useState } from "react";
+
+import { Box, Button, Card, Flex, Link, Select, Spinner, Table, Text } from "@radix-ui/themes";
+
+import { Spacer } from "../../../components/spacer";
+import { SERVICE_STATE } from "../../../constants/service";
+import { useShopData } from "../../../hooks/useShopData";
+import { ServiceStateType } from "../../../types/service.type";
+import { AdminReadWrapper } from "./AdminReadStyle.css";
+import { useNavigate } from "react-router-dom";
+
+export const AdminReadPage = () => {
+  const navigate = useNavigate();
+  const [serviceState, setServiceState] = useState<ServiceStateType>(
+    SERVICE_STATE.OFFLINE,
+  );
+
+  const {
+    data: storeData,
+    isLoading,
+  } = useShopData(serviceState); // category 없이 전체 데이터 가져오기
+
+  return (
+    <div className={AdminReadWrapper}>
+      <Text size="6" weight="bold" mb="4">
+        관리자 페이지
+      </Text>
+      <Spacer height={20} />
+      <Flex gap="3" justify="between" align="center" mb="5">
+        <Flex align="center" gap="3">
+        <Text weight="bold" size="4">
+          온/오프라인 구분
+        </Text>
+        <Select.Root
+          size="3"
+          value={serviceState}
+          onValueChange={(value) => setServiceState(value as ServiceStateType)}
+         
+        >
+          <Select.Trigger />
+          <Select.Content>
+            <Select.Item value={SERVICE_STATE.OFFLINE}>오프라인</Select.Item>
+            <Select.Item value={SERVICE_STATE.ONLINE}>온라인</Select.Item>
+          </Select.Content>
+        </Select.Root>
+        </Flex>
+        <Button size="3" onClick={() => navigate("/stella/admin/write")}>등록하기</Button>
+      </Flex>
+      <Spacer height={20} />
+      {isLoading ? (
+        <Flex justify="center" align="center" py="9">
+          <Spinner size="3" />
+        </Flex>
+      ) : (
+        <Box style={{ overflowX: "auto" }}>
+          <Card>
+            <Table.Root variant='surface'>
+              <Table.Header>
+                <Table.Row>
+                  <Table.ColumnHeaderCell>ID</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>상호명</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>카테고리</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>설명</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>주소</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>전화번호</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>트위터 링크</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>지도/사이트 링크</Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell>인증 여부</Table.ColumnHeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {storeData && storeData.length > 0 ? (
+                  storeData.map((data) => (
+                    <Table.Row key={data.id || data.name}>
+                      <Table.Cell>
+                        <Text size="2" wrap='nowrap'>{data.id || "-"}</Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text size="2">{data.name}</Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text size="2" wrap='nowrap'>{data.category}</Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text size="2" style={{ maxWidth: "300px", wordBreak: "break-word" }}>
+                          {data.description || "-"}
+                        </Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text size="2" style={{ maxWidth: "150px", wordBreak: "break-word" }}>
+                          {data.address || "-"}
+                        </Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text size="2">{data.phone || "-"}</Text>
+                      </Table.Cell>
+                      <Table.Cell>
+                        {data.twitterLink ? (
+                          <Link
+                            href={data.twitterLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            size="2"
+                          >
+                            {data.twitterLink.length > 30
+                              ? `${data.twitterLink.substring(0, 30)}...`
+                              : data.twitterLink}
+                          </Link>
+                        ) : (
+                          <Text size="2">-</Text>
+                        )}
+                      </Table.Cell>
+                      <Table.Cell>
+                        {data.mapLink ? (
+                          <Link
+                            href={data.mapLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            size="2"
+                          >
+                            {data.mapLink.length > 30
+                              ? `${data.mapLink.substring(0, 30)}...`
+                              : data.mapLink}
+                          </Link>
+                        ) : (
+                          <Text size="2">-</Text>
+                        )}
+                      </Table.Cell>
+                      <Table.Cell>
+                        <Text size="2">{data.isVerified ? "✓" : "-"}</Text>
+                      </Table.Cell>
+                    </Table.Row>
+                  ))
+                ) : (
+                  <Table.Row>
+                    <Table.Cell colSpan={9}>
+                      <Text size="2" align="center">
+                        데이터가 없습니다.
+                      </Text>
+                    </Table.Cell>
+                  </Table.Row>
+                )}
+              </Table.Body>
+            </Table.Root>
+          </Card>
+        </Box>
+      )}
+      <Spacer height={20} />
+      <Text size="2" color="gray">
+        총 {storeData?.length || 0}개의 데이터가 있습니다.
+      </Text>
+    </div>
+  );
+};
+


### PR DESCRIPTION
### AS-IS

- 관리자 페이지에는 등록 기능만 있음
- 전체 가게 목록은 확인할 수 없었음 (직접 DB에 접근해야 함)

### TO-BE

- 전체 가게 목록 페이지 생성
- 온/오프라인 구분해서 볼 수 있음
- 등록 페이지는 별도의 버튼으로 분리함
- table ui는 radix-ui 사용

<img width="1698" height="940" alt="image" src="https://github.com/user-attachments/assets/92cd39d9-0a35-4362-b248-46769bd6d123" />
